### PR TITLE
Add validation for price prediction CSV

### DIFF
--- a/pages/Price Prediction.py
+++ b/pages/Price Prediction.py
@@ -6,13 +6,16 @@ st.title("📈 Price Prediction")
 
 uploaded_file = st.file_uploader("Upload CSV with 'feature' and 'price' columns")
 
-if uploaded_file:
+if uploaded_file is not None:
     df = pd.read_csv(uploaded_file)
-    st.write(df.head())
+    if {"feature", "price"}.issubset(df.columns):
+        st.write(df.head())
 
-    model = LinearRegression()
-    model.fit(df[['feature']], df['price'])
+        model = LinearRegression()
+        model.fit(df[["feature"]], df["price"])
 
-    input_val = st.number_input("Enter feature value")
-    prediction = model.predict([[input_val]])
-    st.write(f"Predicted price: ${prediction[0]:.2f}")
+        input_val = st.number_input("Enter feature value")
+        prediction = model.predict([[input_val]])
+        st.write(f"Predicted price: ${prediction[0]:.2f}")
+    else:
+        st.error("Uploaded CSV must contain 'feature' and 'price' columns.")


### PR DESCRIPTION
## Summary
- guard against missing file upload for price prediction
- validate uploaded CSV contains `feature` and `price` columns before training model

## Testing
- `python -m py_compile app.py pages/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6896a677373c83318e9e8b6153367abd